### PR TITLE
Investigate blog content display issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Add `submodules: recursive` to CI checkout to ensure Hugo theme is available for builds.

This fixes an issue where the blog was displaying the default Nginx welcome page because the Hugo theme, which is a git submodule, was not being initialized during the CI build process. Adding `submodules: recursive` ensures the theme is fetched, allowing Hugo to build the correct blog content.